### PR TITLE
added queue priority support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@0xsero/open-queue",
+  "version": "1.0.11",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@0xsero/open-queue",
+      "version": "1.0.11",
+      "license": "MIT",
+      "bin": {
+        "open-queue": "bin/install.js"
+      },
+      "devDependencies": {
+        "@opencode-ai/plugin": "^1.0.150",
+        "@opencode-ai/sdk": "^1.0.150",
+        "@types/node": "^20.14.10",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=1.0.0"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.0.207",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.0.207.tgz",
+      "integrity": "sha512-UOjZ09lVwWv0MRHUcluLm3eeYC7rmQyuSRfaaK6RLKn1bdsypp8lnuw9HZ2nrR5kmkiF12+9yMM4bVgER6lTBw==",
+      "dev": true,
+      "dependencies": {
+        "@opencode-ai/sdk": "1.0.207",
+        "zod": "4.1.8"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.0.207",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.0.207.tgz",
+      "integrity": "sha512-/t4C3+PXZ5NpN7+HwKZmVwJsJmQ1eyub0eQcV8GZh7fuPo2wCxKHCD/lzk82CobW+3jVp2TSBKeDBBTtVvEFeQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces **explicit, user-declared message priority** to the message queue

## What changed

### 1. Explicit message priority (opt-in)

Users can now declare priority directly in the message text using a structured prefix:

```
[priority: high] {prompt …}
[priority: normal] {prompt …}
[priority: low] {prompt …}
```

* Priority is parsed deterministically from the first non-empty text part.
* The prefix is **removed before execution** and does not reach the model.
* Messages without an explicit prefix default to `normal`.

Priority is stored as metadata on each queued message.

---

### 2. Priority-aware queue draining

Queue draining now selects the next message by:

1. Highest priority
2. FIFO order within the same priority

---

### 3. Correct `hold`-mode semantics

In `hold` mode, **all messages are now queued**, including the first message in an idle session.

This ensures that:

* priority extraction always runs,
* queue state is consistent from the first message onward,
* and `hold` behaves as an explicit, predictable buffering mode.

`immediate` mode behavior is unchanged.

---


## Backwards compatibility

* Default behavior remains unchanged unless `hold` mode is explicitly enabled.
* Messages without a priority tag behave exactly as before (`normal` priority).
* No changes to `/queue` command syntax.

---

## Testing

https://github.com/user-attachments/assets/433542a2-688c-4e94-9415-69196a99d9c9


Manually tested:

* `hold` mode with first message queued
* Mixed priority messages (`high`, `normal`, `low`)
* FIFO ordering within same priority
* Prefix stripping before execution
* `immediate` mode unaffected

---

